### PR TITLE
enable returnChartData to have params

### DIFF
--- a/lib/poloniex.rb
+++ b/lib/poloniex.rb
@@ -23,6 +23,10 @@ module Poloniex
     end
   end
 
+  def self.chart_data( currency_pair, start_time, end_time, period)
+    res = get 'returnChartData', currencyPair: currency_pair, period: period,  start: start_time.to_i, :end => end_time.to_i
+  end
+
   def self.get_all_daily_exchange_rates( currency_pair )
     res = get 'returnChartData', currencyPair: currency_pair, period: 86400,  start: 0, :end => Time.now.to_i
   end

--- a/lib/poloniex.rb
+++ b/lib/poloniex.rb
@@ -2,6 +2,7 @@ require "poloniex/version"
 require 'rest-client'
 require 'openssl'
 require 'addressable/uri'
+require 'json'
 
 module Poloniex
 
@@ -135,13 +136,15 @@ module Poloniex
 
   def self.get( command, params = {} )
     params[:command] = command
-    resource[ 'public' ].get params: params
+    response = resource[ 'public' ].get params: params
+    JSON.parse(response.body)
   end
 
   def self.post( command, params = {} )
     params[:command] = command
     params[:nonce]   = (Time.now.to_f * 10000000).to_i
-    resource[ 'tradingApi' ].post params, { Key: configuration.key , Sign: create_sign( params ) }
+    response = resource[ 'tradingApi' ].post params, { Key: configuration.key , Sign: create_sign( params ) }
+    JSON.parse(response.body)
   end
 
   def self.create_sign( data )

--- a/lib/poloniex/version.rb
+++ b/lib/poloniex/version.rb
@@ -1,3 +1,3 @@
 module Poloniex
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
With old version, I could not use returnChartData with params like periods.